### PR TITLE
Fix literal check for coffeescript >= 1.11.0

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -53,7 +53,8 @@ module.exports = class CallbackHandleError
           child.condition.traverseChildren false, (inner_child)->
             inner_type = getNodeType inner_child
             switch inner_type
-              when 'Literal'
+              # HACK: Handles change of token naming in CoffeeScript 1.11.0
+              when 'Literal', 'IdentifierLiteral'
                 if inner_child.value is var_name
                   found_usage = true
                   return false
@@ -65,7 +66,8 @@ module.exports = class CallbackHandleError
             arg.traverseChildren false, (inner_child)->
               inner_type = getNodeType inner_child
               switch inner_type
-                when 'Literal'
+                # HACK: Handles change of token naming in CoffeeScript 1.11.0
+                when 'Literal', 'IdentifierLiteral'
                   if inner_child.value is var_name
                     found_usage = true
                     return false

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@
               inner_type = getNodeType(inner_child);
               switch (inner_type) {
                 case 'Literal':
+                case 'IdentifierLiteral':
                   if (inner_child.value === var_name) {
                     found_usage = true;
                     return false;
@@ -79,6 +80,7 @@
                 inner_type = getNodeType(inner_child);
                 switch (inner_type) {
                   case 'Literal':
+                  case 'IdentifierLiteral':
                     if (inner_child.value === var_name) {
                       found_usage = true;
                       return false;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "homepage": "https://github.com/srgraham/coffeelint-callback-handle-error",
   "dependencies": {
-    "chai": "^3.4.1",
     "coffee-script": "^1.10.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0"
   }
 }


### PR DESCRIPTION
I couldn't figure out how to run the tests or use it locally, but I think this is right?...

Related issue: https://github.com/srgraham/coffeelint-callback-handle-error/issues/2